### PR TITLE
Adding inferred matrix size from ISMRMRD Header

### DIFF
--- a/PowerGrid/MPI/PowerGridPcSenseMPI.cpp
+++ b/PowerGrid/MPI/PowerGridPcSenseMPI.cpp
@@ -59,25 +59,9 @@ int main(int argc, char **argv) {
       "inputData,i", po::value<std::string>(&rawDataFilePath)->required(),
       "input ISMRMRD Raw Data file")
       ("outputImage,o", po::value<std::string>(&outputImageFilePath)->required(), "output file path for NIFTIimages")
-      /*
-      ("inputDataNav,-N", po::value<std::string>(&rawDataNavFilePath), "input
-      ISMRMRD Navigator Raw Data")
-      ("outputImage,o",
-      po::value<std::string>(&outputImageFilePath)->required(), "output ISMRMRD
-      Image file")
-      ("SENSEMap,S", po::value<std::string>(&senseMapFilePath),
-       "Enable SENSE recon with the specified SENSE map in ISMRMRD image
-      format")
-      ("FieldMap,F", po::value<std::string>(&fieldMapFilePath),
-      "Enable field corrected reconstruction with the specified field map in
-      ISMRMRD format")
-      ("Precision,P", po::value<std::string>(&precisionString),
-       "Numerical precision to use, float or double currently supported")
-       */
-       ("Nx,x", po::value<uword>(&Nx)->required(), "Image size in X (Required)")
-       ("Ny,y", po::value<uword>(&Ny)->required(),
-                                     "Image size in Y (Required)")
-      ("Nz,z", po::value<uword>(&Nz)->required(), "Image size in Z (Required)")
+			("Nx,x", po::value<uword>(&Nx), "Image size in X")
+			("Ny,y", po::value<uword>(&Ny), "Image size in Y")
+			("Nz,z", po::value<uword>(&Nz), "Image size in Z")
       ("NShots,s", po::value<uword>(&NShots), "Number of shots per image")
       ("Beta,B", po::value<double>(&beta), "Spatial regularization penalty weight")
       ("Dims2Penalize,D", po::value<uword>(&dims2penalize), "Dimensions to apply regularization to (2 or 3)")
@@ -136,6 +120,17 @@ int main(int argc, char **argv) {
   d->readAcquisition(0, acq);
   uword nro = acq.number_of_samples();
   uword nc = acq.active_channels();
+
+  	// Handle Nx, Ny, Nz
+	if(!vm.count("Nx")) {
+		Nx = hdr.encoding[0].encodedSpace.matrixSize.x;
+	} 
+	if(!vm.count("Ny")) {
+		Ny = hdr.encoding[0].encodedSpace.matrixSize.y;
+	} 
+	if(!vm.count("Nz")) {
+		Nz = hdr.encoding[0].encodedSpace.matrixSize.z;
+	} 
 
   Col<float> ix, iy, iz;
   initImageSpaceCoords(ix, iy, iz, Nx, Ny, Nz);

--- a/PowerGrid/MPI/PowerGridPcSenseMPI_TS.cpp
+++ b/PowerGrid/MPI/PowerGridPcSenseMPI_TS.cpp
@@ -53,9 +53,16 @@ int main(int argc, char** argv)
     po::options_description desc("Allowed options");
     desc.add_options()("help,h", "produce help message")(
         "inputData,i", po::value<std::string>(&rawDataFilePath)->required(),
-        "input ISMRMRD Raw Data file")("outputImage,o", po::value<std::string>(&outputImageFilePath)->required(), "output file path for NIFTIimages")("Nx,x", po::value<uword>(&Nx)->required(), "Image size in X (Required)")("Ny,y", po::value<uword>(&Ny)->required(),
-        "Image size in Y (Required)")("Nz,z", po::value<uword>(&Nz)->required(), "Image size in Z (Required)")("NShots,s", po::value<uword>(&NShots), "Number of shots per image")("TimeSegmentationInterp,I", po::value<std::string>(&TimeSegmentationInterp)->required(), "Field Correction Interpolator (Required)")("TimeSegments,t", po::value<uword>(&L)->required(), "Number of time segments (Required)")("Beta,B", po::value<double>(&beta), "Spatial regularization penalty weight")("Dims2Penalize,D", po::value<uword>(&dims2penalize), "Dimensions to apply regularization to (2 or 3)")("CGIterations,n", po::value<uword>(&NIter), "Number of preconditioned conjugate gradient interations for main "
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  "solver");
+        "input ISMRMRD Raw Data file")
+        ("outputImage,o", po::value<std::string>(&outputImageFilePath)->required(), "output file path for NIFTIimages")
+		("Nx,x", po::value<uword>(&Nx), "Image size in X")
+		("Ny,y", po::value<uword>(&Ny), "Image size in Y")
+		("Nz,z", po::value<uword>(&Nz), "Image size in Z")
+        ("NShots,s", po::value<uword>(&NShots), "Number of shots per image")
+        ("TimeSegmentationInterp,I", po::value<std::string>(&TimeSegmentationInterp)->required(), "Field Correction Interpolator (Required)")
+        ("TimeSegments,t", po::value<uword>(&L)->required(), "Number of time segments (Required)")
+        ("Beta,B", po::value<double>(&beta), "Spatial regularization penalty weight")("Dims2Penalize,D", po::value<uword>(&dims2penalize), "Dimensions to apply regularization to (2 or 3)")
+        ("CGIterations,n", po::value<uword>(&NIter), "Number of preconditioned conjugate gradient interations for main solver");
 
     po::variables_map vm;
 
@@ -110,6 +117,17 @@ int main(int argc, char** argv)
     d->readAcquisition(0, acq);
     nro = acq.number_of_samples();
     nc = acq.active_channels();
+
+    // Handle Nx, Ny, Nz
+	if(!vm.count("Nx")) {
+		Nx = hdr.encoding[0].encodedSpace.matrixSize.x;
+	} 
+	if(!vm.count("Ny")) {
+		Ny = hdr.encoding[0].encodedSpace.matrixSize.y;
+	} 
+	if(!vm.count("Nz")) {
+		Nz = hdr.encoding[0].encodedSpace.matrixSize.z;
+	} 
 
     Col<float> ix, iy, iz;
     initImageSpaceCoords(ix, iy, iz, Nx, Ny, Nz);

--- a/PowerGrid/MPI/PowerGridSenseMPI.cpp
+++ b/PowerGrid/MPI/PowerGridSenseMPI.cpp
@@ -53,9 +53,9 @@ int main(int argc, char **argv) {
       "inputData,i", po::value<std::string>(&rawDataFilePath)->required(),
       "input ISMRMRD Raw Data file")
  			("outputImage,o", po::value<std::string>(&outputImageFilePath)->required(), "output file path for NIFTIimages")
-      ("Nx,x", po::value<uword>(&Nx)->required(), "Image size in X (Required)")
-          ("Ny,y", po::value<uword>(&Ny)->required(), "Image size in Y (Required)")
-          ("Nz,z", po::value<uword>(&Nz)->required(), "Image size in Z (Required)")
+			("Nx,x", po::value<uword>(&Nx), "Image size in X")
+			("Ny,y", po::value<uword>(&Ny), "Image size in Y")
+			("Nz,z", po::value<uword>(&Nz), "Image size in Z")
           ("NShots,s", po::value<uword>(&NShots), "Number of shots per image")
           ("TimeSegmentationInterp,I", po::value<std::string>(&TimeSegmentationInterp)->required(), "Field Correction Interpolator (Required)")
           ("FourierTransform,F", po::value<std::string>(&FourierTrans)->required(), "Implementation of Fourier Transform")
@@ -126,6 +126,17 @@ int main(int argc, char **argv) {
   d->readAcquisition(0, acq);
   uword nro = acq.number_of_samples();
   uword nc = acq.active_channels();
+
+	// Handle Nx, Ny, Nz
+	if(!vm.count("Nx")) {
+		Nx = hdr.encoding[0].encodedSpace.matrixSize.x;
+	} 
+	if(!vm.count("Ny")) {
+		Ny = hdr.encoding[0].encodedSpace.matrixSize.y;
+	} 
+	if(!vm.count("Nz")) {
+		Nz = hdr.encoding[0].encodedSpace.matrixSize.z;
+	} 
 
   Col<float> ix, iy, iz;
   initImageSpaceCoords(ix, iy, iz, Nx, Ny, Nz);

--- a/PowerGrid/PowerGridIsmrmrd.cpp
+++ b/PowerGrid/PowerGridIsmrmrd.cpp
@@ -49,25 +49,9 @@ int main(int argc, char **argv) {
       "inputData,i", po::value<std::string>(&rawDataFilePath)->required(),
       "input ISMRMRD Raw Data file")
  			("outputImage,o", po::value<std::string>(&outputImageFilePath)->required(), "output file path for NIFTIimages")
-
-      /*
-      ("inputDataNav,-N", po::value<std::string>(&rawDataNavFilePath), "input
-      ISMRMRD Navigator Raw Data")
-      ("outputImage,o",
-      po::value<std::string>(&outputImageFilePath)->required(), "output ISMRMRD
-      Image file")
-      ("SENSEMap,S", po::value<std::string>(&senseMapFilePath),
-       "Enable SENSE recon with the specified SENSE map in ISMRMRD image
-      format")
-      ("FieldMap,F", po::value<std::string>(&fieldMapFilePath),
-      "Enable field corrected reconstruction with the specified field map in
-      ISMRMRD format")
-      ("Precision,P", po::value<std::string>(&precisionString),
-       "Numerical precision to use, float or double currently supported")
-       */
-      ("Nx,x", po::value<uword>(&Nx)->required(), "Image size in X (Required)")
-          ("Ny,y", po::value<uword>(&Ny)->required(), "Image size in Y (Required)")
-          ("Nz,z", po::value<uword>(&Nz)->required(), "Image size in Z (Required)")
+			("Nx,x", po::value<uword>(&Nx), "Image size in X")
+			("Ny,y", po::value<uword>(&Ny), "Image size in Y")
+			("Nz,z", po::value<uword>(&Nz), "Image size in Z")
           ("NShots,s", po::value<uword>(&NShots), "Number of shots per image")
           ("TimeSegmentationInterp,I", po::value<std::string>(&TimeSegmentationInterp)->required(), "Field Correction Interpolator (Required)")
           ("FourierTransform,F", po::value<std::string>(&FourierTrans)->required(), "Implementation of Fourier Transform")
@@ -151,6 +135,17 @@ int main(int argc, char **argv) {
   d->readAcquisition(0, acq);
   uword nro = acq.number_of_samples();
   uword nc = acq.active_channels();
+
+  	// Handle Nx, Ny, Nz
+	if(!vm.count("Nx")) {
+		Nx = hdr.encoding[0].encodedSpace.matrixSize.x;
+	} 
+	if(!vm.count("Ny")) {
+		Ny = hdr.encoding[0].encodedSpace.matrixSize.y;
+	} 
+	if(!vm.count("Nz")) {
+		Nz = hdr.encoding[0].encodedSpace.matrixSize.z;
+	} 
 
   Col<float> ix, iy, iz;
   initImageSpaceCoords(ix, iy, iz, Nx, Ny, Nz);

--- a/PowerGrid/PowerGridPcSense.cpp
+++ b/PowerGrid/PowerGridPcSense.cpp
@@ -48,27 +48,14 @@ int main(int argc, char **argv)
 	double beta = 0.0;
 	uword dims2penalize = 3;
 	po::options_description desc("Allowed options");
+
 	desc.add_options()("help,h", "produce help message")
 			("inputData,i", po::value<std::string>(&rawDataFilePath)->required(),
 			"input ISMRMRD Raw Data file")
 			("outputImage,o", po::value<std::string>(&outputImageFilePath)->required(), "output file path for NIFTIimages")
-			/*
-			("inputDataNav,-N", po::value<std::string>(&rawDataNavFilePath), "input
-			ISMRMRD Navigator Raw Data")
-
-			("SENSEMap,S", po::value<std::string>(&senseMapFilePath),
-			 "Enable SENSE recon with the specified SENSE map in ISMRMRD image
-			format")
-			("FieldMap,F", po::value<std::string>(&fieldMapFilePath),
-			"Enable field corrected reconstruction with the specified field map in
-			ISMRMRD format")
-			("Precision,P", po::value<std::string>(&precisionString),
-			 "Numerical precision to use, float or double currently supported")
-			 */
-			("Nx,x", po::value<uword>(&Nx)->required(), "Image size in X (Required)")
-			("Ny,y", po::value<uword>(&Ny)->required(),
-					"Image size in Y (Required)")
-			("Nz,z", po::value<uword>(&Nz)->required(), "Image size in Z (Required)")
+			("Nx,x", po::value<uword>(&Nx), "Image size in X")
+			("Ny,y", po::value<uword>(&Ny), "Image size in Y")
+			("Nz,z", po::value<uword>(&Nz), "Image size in Z")
 			("NShots,s", po::value<uword>(&NShots), "Number of shots per image")
 			("Beta,B", po::value<double>(&beta), "Spatial regularization penalty weight")
 			("Dims2Penalize,D", po::value<uword>(&dims2penalize), "Dimensions to apply regularization to (2 or 3)")
@@ -131,6 +118,19 @@ int main(int argc, char **argv)
 	d->readAcquisition(0, acq);
 	uword nro = acq.number_of_samples();
 	uword nc = acq.active_channels();
+
+	// Handle Nx, Ny, Nz
+	if(!vm.count("Nx")) {
+		Nx = hdr.encoding[0].encodedSpace.matrixSize.x;
+	} 
+	if(!vm.count("Ny")) {
+		Ny = hdr.encoding[0].encodedSpace.matrixSize.y;
+	} 
+	if(!vm.count("Nz")) {
+		Nz = hdr.encoding[0].encodedSpace.matrixSize.z;
+	} 
+
+
 
 	Col<float> ix, iy, iz;
 	initImageSpaceCoords(ix, iy, iz, Nx, Ny, Nz);

--- a/PowerGrid/PowerGridPcSenseTimeSeg.cpp
+++ b/PowerGrid/PowerGridPcSenseTimeSeg.cpp
@@ -52,25 +52,9 @@ int main(int argc, char **argv)
 			"inputData,i", po::value<std::string>(&rawDataFilePath)->required(),
 			"input ISMRMRD Raw Data file")
 			("outputImage,o", po::value<std::string>(&outputImageFilePath)->required(), "output file path for NIFTIimages")
-			/*
-			("inputDataNav,-N", po::value<std::string>(&rawDataNavFilePath), "input
-			ISMRMRD Navigator Raw Data")
-			("outputImage,o",
-			po::value<std::string>(&outputImageFilePath)->required(), "output ISMRMRD
-			Image file")
-			("SENSEMap,S", po::value<std::string>(&senseMapFilePath),
-			 "Enable SENSE recon with the specified SENSE map in ISMRMRD image
-			format")
-			("FieldMap,F", po::value<std::string>(&fieldMapFilePath),
-			"Enable field corrected reconstruction with the specified field map in
-			ISMRMRD format")
-			("Precision,P", po::value<std::string>(&precisionString),
-			 "Numerical precision to use, float or double currently supported")
-			 */
-			("Nx,x", po::value<uword>(&Nx)->required(), "Image size in X (Required)")
-			("Ny,y", po::value<uword>(&Ny)->required(),
-					"Image size in Y (Required)")
-			("Nz,z", po::value<uword>(&Nz)->required(), "Image size in Z (Required)")
+			("Nx,x", po::value<uword>(&Nx), "Image size in X")
+			("Ny,y", po::value<uword>(&Ny), "Image size in Y")
+			("Nz,z", po::value<uword>(&Nz), "Image size in Z")
             ("TimeSegmentationInterp,I", po::value<std::string>(&TimeSegmentationInterp)->required(), "Field Correction Interpolator (Required)")
             ("TimeSegments,t", po::value<uword>(&L)->required(), "Number of time segments (Required)")
 			("NShots,s", po::value<uword>(&NShots), "Number of shots per image")
@@ -144,6 +128,17 @@ int main(int argc, char **argv)
 	d->readAcquisition(0, acq);
 	uword nro = acq.number_of_samples();
 	uword nc = acq.active_channels();
+
+	// Handle Nx, Ny, Nz
+	if(!vm.count("Nx")) {
+		Nx = hdr.encoding[0].encodedSpace.matrixSize.x;
+	} 
+	if(!vm.count("Ny")) {
+		Ny = hdr.encoding[0].encodedSpace.matrixSize.y;
+	} 
+	if(!vm.count("Nz")) {
+		Nz = hdr.encoding[0].encodedSpace.matrixSize.z;
+	} 
 
 	Col<float> ix, iy, iz;
 	initImageSpaceCoords(ix, iy, iz, Nx, Ny, Nz);

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Software for CPU and GPU accelerated iterative magnetic resonance imaging recons
 * 	Install Docker (https://docs.docker.com/install/linux/docker-ce/ubuntu)
 * 	Install Nvidia-docker (https://github.com/NVIDIA/nvidia-docker)
 
+Useful options include `-v /Source/On/Host:/Target/On/Container` to mount a directory of data and/or code onto the scanner.
+
 ```shell
 docker pull mrfil/powergrid-dev
-docker run --runtime=nvidia -it mrfil/powergrid
+docker run --runtime=nvidia -it mrfil/powergrid-dev
 ```
 
 ### Installing dependencies on Ubuntu 16.04 (Not recommended - for advanced users only)


### PR DESCRIPTION
Making the matrix size optional on the command line arguments for our various reconstructions. If not specified, it will read from the ISMRMRD header and use those values for the image size to be reconstructed. 